### PR TITLE
Propozycje zmian

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -19,9 +19,9 @@ def cut_name(matrix: list) -> list:
 
 
 def loss_table(matrix: list) -> list:
-    print(matrix)
+    #print(matrix)
     result = []
-
+    matrix = [[matrix[j][i] for j in range(len(matrix))] for i in range(len(matrix[0]))]
     for x in range(0, len(matrix)):
         maks_list = []
         help = []
@@ -30,6 +30,7 @@ def loss_table(matrix: list) -> list:
         for y in range(0, len(matrix[x])):
             help.append(float(max(maks_list)) - float(matrix[x][y]))
         result.append(help)
+	result = [[result[j][i] for j in range(len(result))] for i in range(len(result[0]))]
     return result
 
 
@@ -96,7 +97,7 @@ def k_savage(matrix: list) -> tuple:
     for line in matrix:
         result.append(max(line))
     for i, num in enumerate(result):
-        if num == max(result):
+        if num == min(result):
             result_index.append(i + 1)
     return result, result_index
 

--- a/main.py
+++ b/main.py
@@ -70,9 +70,9 @@ while not exit:
         input("WCISNIJ ENTER ABY COFNĄĆ")
     elif option == '4':
         prob = []
-        for i in range(len(m)):
+        for i in range(len(m[0])-1):
             prob.append(input("Podaj prawdopodobieństwo dla {} stanu: ".format(i+1)))
-        print_k_bayesa(f.k_bayesa(m, 1/2, 1/2, 1/2, 1/2), prob)
+        print_k_bayesa(f.k_bayesa(m, *prob), prob)
         input("WCISNIJ ENTER ABY COFNĄĆ")
     elif option == '5':
         print_k_savage(f.k_savage(m))

--- a/sample
+++ b/sample
@@ -1,5 +1,4 @@
 gatunek susza upał mokro wilgotnosc
 1 21 15 32 16
-2 28 29 19 20
+2 28 20 10 20
 3 13 27 25 15
-4 28 29 19 20


### PR DESCRIPTION
Podczas testów zauważyłem, że:

1.  W macierzy strat dla kryterium Savage'a obliczamy różnice w wierszach, a trzeba zliczać w kolumnach (tak zrozumiałem ten przykład w wykładzie), więc dodałem transpozycję macierzy
`matrix = [[matrix[j][i] for j in range(len(matrix))] for i in range(len(matrix[0]))]`
tak, aby działać po kolumnach. Na końcu `result` też poddaję transpozycji, aby przywrócić pierwotny wygląd.
2. Dla kryterium Bayesa-Laplace'a dodałem aby wprowadzane prawdopodobieństwa były przekazywane do dalszych obliczeń. Oraz żeby dla każdego stanu zaczytywał te prawdopodobieństwa